### PR TITLE
Bump Rust version to 1.50.0

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,7 +14,7 @@ jobs:
     name: run tests
     strategy:
       matrix:
-        rust: [1.42.0, stable]
+        rust: [1.50.0, stable]
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
@@ -44,7 +44,7 @@ jobs:
       - uses: actions/checkout@v2
       - uses: actions-rs/toolchain@v1
         with:
-            toolchain: 1.47.0
+            toolchain: 1.50.0
             components: clippy
             override: true
       - uses: actions-rs/clippy-check@v1
@@ -59,7 +59,7 @@ jobs:
     - uses: actions/checkout@v2
     - uses: actions-rs/toolchain@v1
       with:
-          toolchain: 1.47.0
+          toolchain: 1.50.0
           override: true
     - run: rustup component add rustfmt
     - uses: actions-rs/cargo@v1


### PR DESCRIPTION
This is consistent with the Tokio rolling MSRV policy of 6 months.