### PR TITLE
ensure correct `Result` type is used

### DIFF
--- a/tracing-test-macro/src/lib.rs
+++ b/tracing-test-macro/src/lib.rs
@@ -103,7 +103,7 @@ pub fn traced_test(_attr: TokenStream, item: TokenStream) -> TokenStream {
             /// Run a function against the log lines. If the function returns
             /// an `Err`, panic. This can be used to run arbitrary assertion
             /// logic against the logs.
-            fn logs_assert(f: impl Fn(&[&str]) -> Result<(), String>) {
+            fn logs_assert(f: impl Fn(&[&str]) -> std::result::Result<(), String>) {
                 match tracing_test::internal::logs_assert(f) {
                     Ok(()) => {},
                     Err(msg) => panic!("The logs_assert function returned an error: {}", msg),


### PR DESCRIPTION
This avoids issues when someone defines their own `Result` type (e.g. `type Result<T> = Result<T, ()>`), _and_ uses this crate's `#[traced_test]`.

See https://github.com/vectordotdev/vector/pull/12655, for an example of where this happened.

I noticed there were other stdlib types used without fully qualified paths, but I left those alone, as overwriting them seems less likely. I'm happy to change them as well, though, please let me know.