### PR TITLE
Add ansi feature, enabling colored log level output

### DIFF
--- a/tracing-test/Cargo.toml
+++ b/tracing-test/Cargo.toml
@@ -27,3 +27,5 @@ maintenance = { status = "experimental" }
 [features]
 # Disable hardcoded env filter
 no-env-filter = ["tracing-test-macro/no-env-filter"]
+# Enable ANSI encoding for colored tracing level output
+ansi = []

--- a/tracing-test/src/lib.rs
+++ b/tracing-test/src/lib.rs
@@ -85,6 +85,9 @@
 //! }
 //! ```
 //!
+//! If you like colored output, you can enable the `ansi` feature,
+//! which enables colored tracing levels in the logs
+//!
 //! ## Rationale / Why You Need This
 //!
 //! Tracing allows you to set a default subscriber within a scope:

--- a/tracing-test/src/subscriber.rs
+++ b/tracing-test/src/subscriber.rs
@@ -61,6 +61,6 @@ pub fn get_subscriber(mock_writer: MockWriter<'static>, env_filter: &str) -> Dis
         .with_env_filter(env_filter)
         .with_writer(mock_writer)
         .with_level(true)
-        .with_ansi(false)
+        .with_ansi(cfg!(feature = "ansi"))
         .into()
 }


### PR DESCRIPTION
I wanted to make more pressing logs to stand out in my test output. Please let me know if you think adding a feature is not the way to go at this