### PR TITLE
Fix incompatibility with llvm-cov

### DIFF
--- a/tracing-test-macro/Cargo.toml
+++ b/tracing-test-macro/Cargo.toml
@@ -27,3 +27,5 @@ maintenance = { status = "experimental" }
 [features]
 # Disable hardcoded env filter
 no-env-filter = []
+# Increase compatibility with llvm-cov
+llvm-cov-compat = []

--- a/tracing-test/Cargo.toml
+++ b/tracing-test/Cargo.toml
@@ -27,3 +27,8 @@ maintenance = { status = "experimental" }
 [features]
 # Disable hardcoded env filter
 no-env-filter = ["tracing-test-macro/no-env-filter"]
+# Increase compatibility with llvm-cov.
+# This prevents `#[traced_tests]` from showing up as uncovered.
+# Note that this requires `#![cfg_attr(coverage_nightly, feature(coverage_attribute))]`
+# to be added to user crates.
+llvm-cov-compat = ["tracing-test-macro/llvm-cov-compat"]


### PR DESCRIPTION
## Rationale

Coverage generated by [`llvm-cov`](https://github.com/taiki-e/cargo-llvm-cov) frequently report `#[traced_test]` as uncovered. ([example](https://coveralls.io/builds/63432754/source?filename=src%2Frunner%2Falive_guard.rs))

Reason is that the generated code in `call_once` only gets executed once per project, and hence all tests (except one) report the code inside of it as uncovered.
Another reason is that the functions `logs_contain` and `logs_assert` do not necessarily have to be used by the programmer.

## Solution
- Move `call_once` into the non-macro part of the library, and call it from the macro part.
- Add feature `llvm-cov-compat` which marks `logs_contain` and `logs_assert` as:
  ```rust
  #[cfg_attr(coverage_nightly, coverage(off))]
  ```

## Todo:
- [x] Confirm that this change fixes the coverage issue. ([example](https://coveralls.io/builds/63444988/source?filename=src%2Frunner%2Falive_guard.rs))