### PR TITLE
Include license text in the packaged crates

### DIFF
--- a/tracing-test-macro-tests/LICENSE-APACHE
+++ b/tracing-test-macro-tests/LICENSE-APACHE
@@ -1,0 +1,1 @@
+../LICENSE-APACHE

--- a/tracing-test-macro-tests/LICENSE-MIT
+++ b/tracing-test-macro-tests/LICENSE-MIT
@@ -1,0 +1,1 @@
+../LICENSE-MIT

--- a/tracing-test-macro/LICENSE-APACHE
+++ b/tracing-test-macro/LICENSE-APACHE
@@ -1,0 +1,1 @@
+../LICENSE-APACHE

--- a/tracing-test-macro/LICENSE-MIT
+++ b/tracing-test-macro/LICENSE-MIT
@@ -1,0 +1,1 @@
+../LICENSE-MIT

--- a/tracing-test/LICENSE-APACHE
+++ b/tracing-test/LICENSE-APACHE
@@ -1,0 +1,1 @@
+../LICENSE-APACHE

--- a/tracing-test/LICENSE-MIT
+++ b/tracing-test/LICENSE-MIT
@@ -1,0 +1,1 @@
+../LICENSE-MIT

--- a/tracing-test/README.md
+++ b/tracing-test/README.md
@@ -1,0 +1,1 @@
+../README.md


### PR DESCRIPTION
This ensures that the license text is included in crates uploaded to crates.io.