### PR TITLE
Docs: Add similar crate

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,7 @@ Similar crates:
   running tests
 - [tracing-fluent-assertions](https://crates.io/crates/tracing-fluent-assertions):
   More powerful assertions that also allow analyzing spans
+- [tracing-assertions]: Provides ergonomic simple assertions on events.
 
 ## Docs / Usage / Example
 

--- a/tracing-test/src/lib.rs
+++ b/tracing-test/src/lib.rs
@@ -10,6 +10,7 @@
 //!   running tests
 //! - [tracing-fluent-assertions](https://crates.io/crates/tracing-fluent-assertions):
 //!   More powerful assertions that also allow analyzing spans
+//! - [tracing-assertions]: Provides ergonomic simple assertions on events.
 //!
 //! ## Usage
 //!


### PR DESCRIPTION
I've created a similar crate, so I thought it could be useful to link it here among other similar crates. I also updated my crate to link to this e.g. https://crates.io/crates/tracing-assertions.