### PR TITLE
feat: enable ansi colors and RUST_LOG filtering on stderr output

### DIFF
--- a/tracing-test/Cargo.toml
+++ b/tracing-test/Cargo.toml
@@ -13,7 +13,7 @@ categories = ["development-tools::testing"]
 
 [dependencies]
 tracing-core = "0.1"
-tracing-subscriber = { version = "0.3", features = ["env-filter"] }
+tracing-subscriber = { version = "0.3", features = ["env-filter", "registry"] }
 tracing-test-macro = { path = "../tracing-test-macro", version = "0.2.5" }
 
 [dev-dependencies]


### PR DESCRIPTION
While the crate description states that this crate is not intended for debugging tests but on testing the logging (which is great), we frequently still need to debug tests. We recently moved from a home-baked solution to this crate and really like the ability to assert log lines. At the same time, we quite miss the colored output and a way to set a custom filter directive when debugging tests.

This PR uses a different fmt layer for outputting the logs to the terminal, while keeping the layer used for assertions as it is now. The new layer for outputting allows to set a filter via `RUST_LOG` (while defaulting to the current filter of "trace for main crate"), and enables ansi colors unless `NO_COLOR=1` is present.

The layer that is used for the assertions is kept unchanged (no ansi, no way to change the filter apart from the feature flag).