### PR TITLE
Enforce version equality between tracing-test and tracing-test-macro

### DIFF
--- a/tracing-test/Cargo.toml
+++ b/tracing-test/Cargo.toml
@@ -14,7 +14,7 @@ categories = ["development-tools::testing"]
 [dependencies]
 tracing-core = "0.1"
 tracing-subscriber = { version = "0.3", features = ["env-filter"] }
-tracing-test-macro = { path = "../tracing-test-macro", version = "0.2.5" }
+tracing-test-macro = { path = "../tracing-test-macro", version = "=0.2.5" }
 
 [dev-dependencies]
 tokio = { version = "1", features = ["rt-multi-thread", "macros"] } # Used for doctests


### PR DESCRIPTION
It appears that one version of `tracing-test-macro` is specific to one version of `tracing-test`, in general. When there is a mismatch (for example because a tool like Dependabot updated one but not the other) then the tests fail to compile.

```console
error[E0425]: cannot find function `global_buf` in module `tracing_test::internal`
   --> src/main.rs:5:1
    |
  5 | #[traced_test]
    | ^^^^^^^^^^^^^^
    |
   ::: $CARGO_HOME/registry/src/index.crates.io-1949cf8c6b5b557f/lazy_static-1.5.0/src/lib.rs:167:47
    |
167 |         __lazy_static_internal!($(#[$attr])* (pub) static ref $N : $T = $e; $($t)*);
    |                                               --- similarly named static `GLOBAL_BUF` defined here
    |
    = note: this error originates in the attribute macro `traced_test` (in Nightly builds, run with -Z macro-backtrace for more info)
help: a static with a similar name exists
    |
  5 - #[traced_test]
  5 + GLOBAL_BUF
    |
```